### PR TITLE
fix: compilation failure on Verilator 5.024

### DIFF
--- a/verilator/src/module.rs
+++ b/verilator/src/module.rs
@@ -231,7 +231,7 @@ extern "C" {{
   }}
 
   void
-  {c_ty}_trace(V{c_ty}* __ptr, VerilatedVcdC* __tfp, int __levels) {{
+  {c_ty}_trace(V{c_ty}* __ptr, VerilatedTraceBaseC* __tfp, int __levels) {{
     __ptr->trace(__tfp, __levels);
   }}
 


### PR DESCRIPTION
As this is the most recently updated fork of `verilated-rs`, I'm submitting this here - anyone else reading can feel free to include this minor change.

On Fedora, on Verilator 5.024, the example fails to compile with the following error:

```
/home/pete/prog/axi-livesim/verilated-rs/target/debug/build/example-440d8f04ede467ee/out/top.cpp: In function ‘void top_trace(Vtop*, VerilatedVcdC*, int)’:
/home/pete/prog/axi-livesim/verilated-rs/target/debug/build/example-440d8f04ede467ee/out/top.cpp:26:18: error: cannot convert ‘VerilatedVcdC*’ to ‘VerilatedTraceBaseC*’
   26 |     __ptr->trace(__tfp, __levels);
      |                  ^~~~~
      |                  |
      |                  VerilatedVcdC*
In file included from /home/pete/prog/axi-livesim/verilated-rs/target/debug/build/example-440d8f04ede467ee/out/top.cpp:1:
./Vtop.h:69:37: note:   initializing argument 1 of ‘void Vtop::trace(VerilatedTraceBaseC*, int, int)’
   69 |     void trace(VerilatedTraceBaseC* tfp, int levels, int options = 0) { contextp()->trace(tfp, levels, options); }
      |                ~~~~~~~~~~~~~~~~~~~~~^~~
make: *** [Vtop.mk:58: top.o] Error 1

```

The breakage can be traced to the following upstream PR:
https://github.com/verilator/verilator/commit/28718f964a844e920fb1129bcdb5ea1cfdc82efb